### PR TITLE
Change Open Store Author to Rinigus

### DIFF
--- a/packaging/ubports/manifest.json
+++ b/packaging/ubports/manifest.json
@@ -10,6 +10,6 @@
         }
     },
     "version": "1.16.1",
-    "maintainer": "Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>",
+    "maintainer": "Rinigus <rinigus.git@gmail.org>",
     "framework" : "ubuntu-sdk-16.04"
 }


### PR DESCRIPTION
Open Store displays the `maintainer` from `manifest.json` as Author.