### PR TITLE
Fix translations for ubports

### DIFF
--- a/osmscout-server.pro
+++ b/osmscout-server.pro
@@ -146,8 +146,10 @@ DEFINES += APP_NAME=\\\"$$APP_NAME\\\"
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 scout_silica {
     DEFINES += IS_SAILFISH_OS
-} else:scout_qtcontrols|scout_kirigami|scout_ubports {
+} else:scout_qtcontrols|scout_kirigami {
     DEFINES += IS_QTCONTROLS_QT
+} else:scout_ubports {
+    DEFINES += IS_QTCONTROLS_QT IS_UBPORTS
 } else {
     DEFINES += IS_CONSOLE_QT
 }
@@ -322,10 +324,24 @@ TRANSLATIONS += \
     translations/$${TARGET}-it_IT.ts \
     translations/$${TARGET}-pt_BR.ts
 
-scout_kirigami|scout_qtcontrols|scout_ubports {
+scout_kirigami|scout_qtcontrols {
     CONFIG += lrelease embed_translations
 }
 
+scout_ubports {
+    qtPrepareTool(LRELEASE, lrelease)
+    for(tsfile, TRANSLATIONS) {
+        qmfile = $$shadowed($$tsfile)
+        qmfile ~= s,.ts$,.qm,
+        qmdir = $$dirname(qmfile)
+        !exists($$qmdir) {
+            mkpath($$qmdir)|error("Aborting.")
+        }
+        command = $$LRELEASE -removeidentical $$tsfile -qm $$qmfile
+        system($$command)|error("Failed to run: $$command")
+        TRANSLATIONS_FILES += $$qmfile
+    }
+}
 
 DISTFILES += $${TARGET}.desktop
 

--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -42,6 +42,7 @@
   ],
   "postbuild": "mv ${INSTALL_DIR}/usr/bin/* ${INSTALL_DIR}",
   "install_data": {
+    "${BUILD_DIR}/translations": "${INSTALL_DIR}",
     "${ROOT}/icons/osmscout-server.svg": "${INSTALL_DIR}",
     "${ROOT}/packaging/ubports/osmscout-server.desktop": "${INSTALL_DIR}",
     "${ROOT}/packaging/ubports/osmscout-server.apparmor": "${INSTALL_DIR}",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,11 +149,12 @@ int main(int argc, char *argv[])
   {
     QString tr_path;
 
-#ifdef IS_SAILFISH_OS
-    tr_path = SailfishApp::pathTo(QString("translations")).toLocalFile();
-#endif
-#ifdef IS_QTCONTROLS_QT
+#if defined(IS_UBPORTS)
+    tr_path = "./translations";
+#elif defined(IS_QTCONTROLS_QT)
     tr_path = ":/i18n";
+#elif defined(IS_SAILFISH_OS)
+    tr_path = SailfishApp::pathTo(QString("translations")).toLocalFile();
 #endif
 
     if ( !tr_path.isEmpty() )


### PR DESCRIPTION
`CONFIG += lrelease embed_translations` in QMake is not supported in Qt 5.9. Therefore I added a custom ubports target which enables translations on Ubuntu Touch.