### PR TITLE
Change app name for ubports full version

### DIFF
--- a/packaging/ubports/full-build.json
+++ b/packaging/ubports/full-build.json
@@ -44,7 +44,7 @@
     "gcc-opt",
     "desktop-file-utils"
   ],
-  "postbuild": "mv ${INSTALL_DIR}/usr/bin/* ${INSTALL_DIR}",
+  "postbuild": "mv ${INSTALL_DIR}/usr/bin/* ${INSTALL_DIR} && sed -i 's/osmscout-server.jonnius/osmscout-server-full.jonius/g' ${INSTALL_DIR}/manifest.json",
   "install_data": {
     "${BUILD_DIR}/translations": "${INSTALL_DIR}",
     "${ROOT}/icons/osmscout-server.svg": "${INSTALL_DIR}",


### PR DESCRIPTION
The slim and full version need distinct names to be uploaded to the OpenStore.