### PR TITLE
Fix MHD_* function signatures for libmicrohttpd >= 0.9.71

### DIFF
--- a/src/requestmapper.cpp
+++ b/src/requestmapper.cpp
@@ -254,7 +254,7 @@ static bool has(const QString &key, QJsonObject &options, MHD_Connection *q)
 //  return MHD_YES;
 //}
 
-static int query_json_iterator(void *cls, enum MHD_ValueKind /*kind*/, const char *key, const char *value)
+static MHD_Result query_json_iterator(void *cls, enum MHD_ValueKind /*kind*/, const char *key, const char *value)
 {
   QString *s = (QString*)cls;
   if ( !s->isEmpty() ) (*s) += ",";

--- a/src/uhttp/microhttpserver.cpp
+++ b/src/uhttp/microhttpserver.cpp
@@ -87,7 +87,7 @@ static ssize_t content_reader_callback (void *cls, uint64_t pos, char *buf, size
   return tosend;
 }
 
-static int answer_to_connection (void *cls, struct MHD_Connection *connection,
+static MHD_Result answer_to_connection (void *cls, struct MHD_Connection *connection,
                                  const char *url, const char *method,
                                  const char */*version*/, const char *upload_data,
                                  size_t *upload_data_size, void **con_cls)
@@ -139,7 +139,7 @@ static int answer_to_connection (void *cls, struct MHD_Connection *connection,
 
   struct MHD_Response *response;
 
-  int ret;
+  MHD_Result ret;
 
   response =
       MHD_create_response_from_callback(-1, 1024*1024,


### PR DESCRIPTION
requestmapper.cpp fails to build on my system:
```
src/requestmapper.cpp: In member function 'virtual unsigned int RequestMapper::service(const char*, MHD_Connection*, MHD_Response*, MicroHTTP::Connection::keytype)':
src/requestmapper.cpp:994:72: error: invalid conversion from 'int (*)(void*, MHD_ValueKind, const char*, const char*)' to 'MHD_KeyValueIterator' {aka 'MHD_Result (*)(void*, MHD_ValueKind, const char*, const char*)'} [-fpermissive]
  994 |           MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, query_json_iterator, &json);
      |                                                                        ^~~~~~~~~~~~~~~~~~~
      |                                                                        |
      |                                                                        int (*)(void*, MHD_ValueKind, const char*, const char*)
In file included from src/uhttp/microhttpserver.h:23,
                 from src/uhttp/microhttpconnection.h:23,
                 from src/uhttp/microhttpservicebase.h:23,
                 from src/requestmapper.h:23,
                 from src/requestmapper.cpp:20:
/nix/store/i1hymy6blzw55b5kys58rjapkmmmlmlz-libmicrohttpd-0.9.71-dev/include/microhttpd.h:2699:49: note:   initializing argument 3 of 'int MHD_get_connection_values(MHD_Connection*, MHD_ValueKind, MHD_KeyValueIterator, void*)'
 2699 |                            MHD_KeyValueIterator iterator,
      |                            ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

I assume some versions of gcc are happy implicitly casting between the two function return types (`int` vs `MHD_Result`), but the one on my system is stricter (or has the function signature changed in libmicrohttpd? not sure).

System is NixOS linux with gcc 9.30, and libmicrohttd 0.9.71.