### PR TITLE
Add X-Purism-FormFactor to desktop files

### DIFF
--- a/gui/osmscout-server-gui.desktop
+++ b/gui/osmscout-server-gui.desktop
@@ -3,6 +3,7 @@ Type=Application
 Icon=osmscout-server
 Exec=osmscout-server-gui
 Name=OSM Scout Server
+X-Purism-FormFactor=Workstation;Mobile;
 
 # translation example:
 # your app name in German locale (de)

--- a/packaging/flatpak/io.github.rinigus.OSMScoutServer.desktop
+++ b/packaging/flatpak/io.github.rinigus.OSMScoutServer.desktop
@@ -4,3 +4,4 @@ Exec=osmscout-server-gui
 Type=Application
 Icon=io.github.rinigus.OSMScoutServer
 Categories=Science;Maps;Qt;
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
Without a properly set X-Purism-FormFactor value,
the Phosh (Wayland shell for GNOME) does not show the
the app, unless the "Show only adaptive apps" radio button
is unticked. Since the GUI of osmscout-server is fully adaptive
and ready to be used, we should declare the form factor to be
mobile ready.