### PR TITLE
Add valhalla 3.4.0 config

### DIFF
--- a/data/valhalla.json-3.4.0
+++ b/data/valhalla.json-3.4.0
@@ -1,0 +1,282 @@
+{
+  "additional_data": {
+    "elevation": "/data/valhalla/elevation/"
+  },
+  "httpd": {
+    "service": {
+      "drain_seconds": 28,
+      "interrupt": "ipc:///tmp/osmscout_server_valhalla_interrupt",
+      "listen": "tcp://127.0.0.1:TCPIP_ROUTE_PORT",
+      "loopback": "ipc:///tmp/osmscout_server_valhalla_loopback",
+      "shutdown_seconds": 1
+    }
+  },
+  "loki": {
+    "actions": [
+      "locate",
+      "route",
+      "height",
+      "sources_to_targets",
+      "optimized_route",
+      "isochrone",
+      "trace_route",
+      "trace_attributes",
+      "transit_available",
+      "expansion",
+      "centroid",
+      "status"
+    ],
+    "logging": {
+      "color": false,
+      "file_name": "path_to_some_file.log",
+      "long_request": 3000.0,
+      "type": "osmscout"
+    },
+    "service": {
+      "proxy": "ipc:///tmp/osmscout_server_valhalla_loki"
+    },
+    "service_defaults": {
+      "heading_tolerance": 60,
+      "minimum_reachability": 50,
+      "node_snap_tolerance": 5,
+      "radius": 0,
+      "search_cutoff": 35000,
+      "street_side_max_distance": 1000,
+      "street_side_tolerance": 5
+    },
+    "use_connectivity": true
+  },
+  "meili": {
+    "auto": {
+      "search_radius": 50,
+      "turn_penalty_factor": 200
+    },
+    "bicycle": {
+      "turn_penalty_factor": 140
+    },
+    "customizable": [
+      "mode",
+      "search_radius",
+      "turn_penalty_factor",
+      "gps_accuracy",
+      "interpolation_distance",
+      "sigma_z",
+      "beta",
+      "max_route_distance_factor",
+      "max_route_time_factor"
+    ],
+    "default": {
+      "beta": 3,
+      "breakage_distance": 2000,
+      "geometry": false,
+      "gps_accuracy": 5.0,
+      "interpolation_distance": 10,
+      "max_route_distance_factor": 5,
+      "max_route_time_factor": 5,
+      "max_search_radius": 100,
+      "route": true,
+      "search_radius": 50,
+      "sigma_z": 4.07,
+      "turn_penalty_factor": 0
+    },
+    "grid": {
+      "cache_size": 100240,
+      "size": 500
+    },
+    "logging": {
+      "color": false,
+      "file_name": "path_to_some_file.log",
+      "type": "osmscout"
+    },
+    "mode": "auto",
+    "multimodal": {
+      "turn_penalty_factor": 70
+    },
+    "pedestrian": {
+      "search_radius": 50,
+      "turn_penalty_factor": 100
+    },
+    "service": {
+      "proxy": "ipc:///tmp/osmscout_server_valhalla_meili"
+    },
+    "verbose": false
+  },
+  "mjolnir": {
+    "admin": "tiles/admin.sqlite",
+    "data_processing": {
+      "allow_alt_name": false,
+      "apply_country_overrides": true,
+      "infer_internal_intersections": true,
+      "infer_turn_channels": true,
+      "scan_tar": false,
+      "use_admin_db": true,
+      "use_direction_on_ways": false,
+      "use_rest_area": false,
+      "use_urban_tag": false
+    },
+    "global_synchronized_cache": false,
+    "hierarchy": true,
+    "id_table_size": 1300000000,
+    "import_bike_share_stations": false,
+    "include_bicycle": true,
+    "include_driveways": true,
+    "include_driving": true,
+    "include_pedestrian": true,
+    "logging": {
+      "color": false,
+      "file_name": "path_to_some_file.log",
+      "type": "osmscout"
+    },
+    "lru_mem_cache_hard_control": false,
+    "max_cache_size": MAXIMAL_CACHE_SIZE,
+    "max_concurrent_reader_users": 1,
+    "reclassify_links": true,
+    "shortcuts": true,
+    "tile_dir": "VALHALLA_TILE_DIRECTORY",
+    "tile_extract": "/data/valhalla/tiles.tar",
+    "timezone": "tiles/tz_world.sqlite",
+    "traffic_extract": "/data/valhalla/traffic.tar",
+    "transit_dir": "transit",
+    "transit_feeds_dir": "transit_feeds",
+    "use_lru_mem_cache": false,
+    "use_simple_mem_cache": false
+  },
+  "odin": {
+    "logging": {
+      "color": false,
+      "file_name": "path_to_some_file.log",
+      "type": "osmscout"
+    },
+    "markup_formatter": {
+      "markup_enabled": false,
+      "phoneme_format": "<TEXTUAL_STRING> (<span class=<QUOTES>phoneme<QUOTES>>/<VERBAL_STRING>/</span>)"
+    },
+    "service": {
+      "proxy": "ipc:///tmp/osmscout_server_valhalla_odin"
+    }
+  },
+  "service_limits": {
+    "auto": {
+      "max_distance": LIMIT_MAX_DISTANCE_AUTO,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "bicycle": {
+      "max_distance": LIMIT_MAX_DISTANCE_BICYCLE,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "bikeshare": {
+      "max_distance": LIMIT_MAX_DISTANCE_BICYCLE,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "bus": {
+      "max_distance": LIMIT_MAX_DISTANCE_AUTO,
+      "max_locations": 50,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "centroid": {
+      "max_distance": 200000.0,
+      "max_locations": 5
+    },
+    "isochrone": {
+      "max_contours": 4,
+      "max_distance": 25000.0,
+      "max_distance_contour": 200,
+      "max_locations": 1,
+      "max_time_contour": 120
+    },
+    "max_alternates": 2,
+    "max_distance_disable_hierarchy_culling": 0,
+    "max_exclude_locations": 50,
+    "max_exclude_polygons_length": 10000,
+    "max_radius": 200,
+    "max_reachability": 100,
+    "max_timedep_distance": LIMIT_MAX_DISTANCE_AUTO,
+    "motor_scooter": {
+      "max_distance": LIMIT_MAX_DISTANCE_BICYCLE,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "motorcycle": {
+      "max_distance": LIMIT_MAX_DISTANCE_AUTO,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "multimodal": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 0,
+      "max_matrix_location_pairs": 0
+    },
+    "pedestrian": {
+      "max_distance": LIMIT_MAX_DISTANCE_PEDESTRIAN,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500,
+      "max_transit_walking_distance": 10000,
+      "min_transit_walking_distance": 1
+    },
+    "skadi": {
+      "max_shape": 750000,
+      "min_resample": 10.0
+    },
+    "status": {
+      "allow_verbose": false
+    },
+    "taxi": {
+      "max_distance": LIMIT_MAX_DISTANCE_AUTO,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "trace": {
+      "max_alternates": 3,
+      "max_alternates_shape": 100,
+      "max_distance": 200000.0,
+      "max_gps_accuracy": 100.0,
+      "max_search_radius": 100.0,
+      "max_shape": 16000
+    },
+    "transit": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_location_pairs": 2500
+    },
+    "truck": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_location_pairs": 2500
+    }
+  },
+  "statsd": {
+    "port": 8125,
+    "prefix": "valhalla"
+  },
+  "thor": {
+    "extended_search": false,
+    "logging": {
+      "color": false,
+      "file_name": "path_to_some_file.log",
+      "long_request": 3000.0,
+      "type": "osmscout"
+    },
+    "max_reserved_labels_count_astar": 2000000,
+    "max_reserved_labels_count_bidir_astar": 1000000,
+    "max_reserved_labels_count_bidir_dijkstras": 2000000,
+    "max_reserved_labels_count_dijkstras": 4000000,
+    "service": {
+      "proxy": "ipc:///tmp/osmscout_server_valhalla_thor"
+    },
+    "source_to_target_algorithm": "select_optimal"
+  }
+}

--- a/server/src/valhallamaster.cpp
+++ b/server/src/valhallamaster.cpp
@@ -173,7 +173,9 @@ void ValhallaMaster::onValhallaChanged(QString valhalla_directory, QStringList c
 void ValhallaMaster::generateConfig()
 {
   QString fname = VALHALLA_CONFIG_TEMPLATE "-";
-#if VALHALLA_VERSION_CURRENT >= VALHALLA_VERSION(3,2,1)
+#if VALHALLA_VERSION_CURRENT >= VALHALLA_VERSION(3,4,0)
+  fname += QStringLiteral("3.4.0");
+#elif VALHALLA_VERSION_CURRENT >= VALHALLA_VERSION(3,2,1)
   fname += QStringLiteral("3.2.1");
 #elif VALHALLA_VERSION_CURRENT >= VALHALLA_VERSION(3,1,4)
   fname += QStringLiteral("3.1.4");


### PR DESCRIPTION
Hopefully fixes #418 and unblocks https://github.com/NixOS/nixpkgs/pull/248414

Tested with osmscout-server 3.0.0 (rebased onto master for this PR) with valhalla 3.4.0 on NixOS. osmscout-server starts, loads the new valhalla config without errors. Pure-maps is able to request routing from osmscout-server and appears to get reasonable routes in response.

I haven't tested for regressions on Sailfish or with older versions of valhalla on any platform, but it's a relatively simple change, so I'm not expecting any regressions.