### PR TITLE
Adjust path colour in mc.json to contrast with background

### DIFF
--- a/styles/mapboxgl/styles/mc-en.json
+++ b/styles/mapboxgl/styles/mc-en.json
@@ -740,7 +740,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-dasharray": [
           1.5,
           0.75
@@ -1720,7 +1720,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-dasharray": [
           1.5,
           0.75
@@ -2662,7 +2662,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -2705,7 +2705,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-width": {
           "base": 1.2,
           "stops": [

--- a/styles/mapboxgl/styles/mc.json
+++ b/styles/mapboxgl/styles/mc.json
@@ -740,7 +740,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-dasharray": [
           1.5,
           0.75
@@ -1720,7 +1720,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-dasharray": [
           1.5,
           0.75
@@ -2662,7 +2662,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -2705,7 +2705,7 @@
         ]
       ],
       "paint": {
-        "line-color": "#00415F",
+        "line-color": "#107c9c",
         "line-width": {
           "base": 1.2,
           "stops": [


### PR DESCRIPTION
In the mc / "Midnight Commander" (night) style footpaths were rendered using the same colour as the generic background. As such they were only visible when they crossed areas with a different coloured background, such as woodland, AONBs, etc. This changes them to use a colour which is visible on all backgrounds, but still in keeping with the colour scheme.
Before:
![Before](https://github.com/rinigus/osmscout-server/assets/1391883/73f10502-2863-4cb6-8745-b18a1c5d3d7a)
After:
![After](https://github.com/rinigus/osmscout-server/assets/1391883/74a2d822-d2b5-41b0-8e0b-d70511217b0c)
