### PR TITLE
Drop C++14 config option

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -53,7 +53,7 @@ QT += core network dbus
 # of the options specified above
 
 # Overall CONFIG
-CONFIG += c++14 object_parallel_to_source
+CONFIG += object_parallel_to_source
 CONFIG += link_pkgconfig
 
 # PREFIX


### PR DESCRIPTION
Not needed for SFOS either and can be dropped