### PR TITLE
fix range-loop-construct warnings

### DIFF
--- a/server/src/mapmanagerfeature.cpp
+++ b/server/src/mapmanagerfeature.cpp
@@ -555,7 +555,7 @@ FeatureValhalla::PackStateType FeatureValhalla::getPackState(QString pack, QStri
     {
       QStringList tiles = getPackTileNames(listname);
       if (tiles.isEmpty()) return PackNotAvailable; // either list is empty or there was error opening it
-      for (const QString tilename: tiles)
+      for (const QString &tilename: tiles)
         if (!dir.exists(m_path_provider->fullPath(tilename)))
           {
             return PackNotAvailable;
@@ -653,7 +653,7 @@ void FeatureValhalla::fillWantedFiles(const QJsonObject &request,
       wanted.insert( listname );
 
       QStringList tiles = getPackTileNames(listname);
-      for (const QString tilename: tiles)
+      for (const QString &tilename: tiles)
         wanted.insert( m_path_provider->fullPath(tilename) );
     }
 }


### PR DESCRIPTION
Costly copying of QString on each for cycle iteration should be avoided.

warning:
```
src/mapmanagerfeature.cpp: In member function 'MapManager::FeatureValhalla::PackStateType MapManager::FeatureValhalla::getPackState(QString, QString, QString) const':
src/mapmanagerfeature.cpp:558:26: warning: loop variable 'tilename' creates a copy from type 'const QString' [-Wrange-loop-construct]
  558 |       for (const QString tilename: tiles)
      |                          ^~~~~~~~
src/mapmanagerfeature.cpp:558:26: note: use reference type to prevent copying
  558 |       for (const QString tilename: tiles)
      |                          ^~~~~~~~
      |                          &
src/mapmanagerfeature.cpp: In member function 'virtual void MapManager::FeatureValhalla::fillWantedFiles(const QJsonObject&, QSet<QString>&)':
src/mapmanagerfeature.cpp:656:26: warning: loop variable 'tilename' creates a copy from type 'const QString' [-Wrange-loop-construct]
  656 |       for (const QString tilename: tiles)
      |                          ^~~~~~~~
src/mapmanagerfeature.cpp:656:26: note: use reference type to prevent copying
  656 |       for (const QString tilename: tiles)
      |                          ^~~~~~~~
      |                          &
```