### PR TITLE
Target Ubuntu Touch noble

### DIFF
--- a/packaging/click/README.md
+++ b/packaging/click/README.md
@@ -21,9 +21,14 @@ The click packages can be found in **click_release**.
 
 Otherwise, follow the instructions below.
 
-## Dependencies
+## Ubuntu Touch Focal
 
-**WARNING**: Dependencies may take hours to build.
+To target an older Ubuntu Touch system, set the `CLICKABLE_FRAMEWORK` env var,
+Ex:
+
+    export CLICKABLE_FRAMEWORK=ubuntu-sdk-20.04
+
+## Dependencies
 
 Run the following command to download and compile the app dependencies:
 

--- a/packaging/click/clickable.yaml
+++ b/packaging/click/clickable.yaml
@@ -1,9 +1,9 @@
-clickable_minimum_required: 8.0.1
+clickable_minimum_required: 8.6.0
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ${ROOT}/packaging/click/prepare-deps.sh
 
-framework: ubuntu-sdk-20.04
+framework: ubuntu-touch-24.04-1.x
 ignore_review_errors: true
 
 builder: qmake
@@ -19,7 +19,7 @@ build_args:
 env_vars:
   PKG_CONFIG_PATH: ${VALHALLA_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig
 postbuild:
-- ln -s ../../usr/bin ${CLICK_PATH}
+- ln -s ../../../usr/bin/osmscout-server{,-gui} ${CLICK_PATH}/
 
 dependencies_host:
 - gcc-opt
@@ -42,7 +42,10 @@ dependencies_target:
 - qttools5-dev
 - libsqlite3-dev
 - libsystemd-dev
+- bzip2
 
+install_bin:
+- bunzip2
 install_lib:
 - /usr/lib/${ARCH_TRIPLET}/libmicrohttpd.so*
 - /usr/lib/${ARCH_TRIPLET}/libkyotocabinet.so*

--- a/packaging/click/manifest.json
+++ b/packaging/click/manifest.json
@@ -9,7 +9,7 @@
             "desktop":  "osmscout-server.desktop"
         }
     },
-    "version": "3.1.0",
+    "version": "3.1.5-@CLICK_FRAMEWORK_BASE@",
     "maintainer": "Rinigus <rinigus.git@gmail.org>",
     "framework" : "@CLICK_FRAMEWORK@"
 }

--- a/packaging/click/osmscout-server.apparmor
+++ b/packaging/click/osmscout-server.apparmor
@@ -1,5 +1,5 @@
 {
     "template": "unconfined",
     "policy_groups": [],
-    "policy_version": 20.04
+    "policy_version": "@APPARMOR_POLICY@"
 }

--- a/packaging/click/patches/valhalla/0001-gcc13-was-missing-some-std-header-includes-4154.patch
+++ b/packaging/click/patches/valhalla/0001-gcc13-was-missing-some-std-header-includes-4154.patch
@@ -1,0 +1,61 @@
+From ed93f30272377cc6803533a1bb94fe81d14af81c Mon Sep 17 00:00:00 2001
+From: Nils <nilsnolde@proton.me>
+Date: Thu, 8 Jun 2023 14:27:30 +0200
+Subject: [PATCH] gcc13 was missing some std header includes (#4154)
+
+---
+ CHANGELOG.md                    | 1 +
+ src/baldr/transitdeparture.cc   | 2 ++
+ src/baldr/transitschedule.cc    | 3 ++-
+ valhalla/baldr/graphconstants.h | 1 +
+ 4 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index d80670b41..1dfa8b0e2 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -1,6 +1,7 @@
+ ## Release Date: 2022-??-?? Valhalla 3.4.1
+ * **Removed**
+ * **Bug Fix**
++   * FIXED: gcc13 was missing some std header includes [#4154](https://github.com/valhalla/valhalla/pull/4154)
+ * **Enhancement**
+ 
+ ## Release Date: 2023-05-11 Valhalla 3.4.0
+diff --git a/src/baldr/transitdeparture.cc b/src/baldr/transitdeparture.cc
+index 7299a7216..5e9bada19 100644
+--- a/src/baldr/transitdeparture.cc
++++ b/src/baldr/transitdeparture.cc
+@@ -1,3 +1,5 @@
++#include <stdexcept>
++
+ #include "baldr/transitdeparture.h"
+ #include "midgard/logging.h"
+ 
+diff --git a/src/baldr/transitschedule.cc b/src/baldr/transitschedule.cc
+index cf3091ecb..4d91e4722 100644
+--- a/src/baldr/transitschedule.cc
++++ b/src/baldr/transitschedule.cc
+@@ -1,5 +1,6 @@
+-#include "baldr/transitschedule.h"
++#include <stdexcept>
+ 
++#include "baldr/transitschedule.h"
+ #include "midgard/logging.h"
+ 
+ namespace valhalla {
+diff --git a/valhalla/baldr/graphconstants.h b/valhalla/baldr/graphconstants.h
+index 6108a8a78..9605ddda5 100644
+--- a/valhalla/baldr/graphconstants.h
++++ b/valhalla/baldr/graphconstants.h
+@@ -2,6 +2,7 @@
+ #define VALHALLA_BALDR_GRAPHCONSTANTS_H_
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <limits>
+ #include <string>
+ #include <unordered_map>
+-- 
+2.43.0
+

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -5,10 +5,15 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 CLONE_ARGS="--recursive --shallow-submodules --depth 1"
 LIBPOSTAL_SRC_DIR="${ROOT_DIR}/libs/libpostal"
 VALHALLA_SRC_DIR="${ROOT_DIR}/libs/valhalla"
+PATCH_DIR=$ROOT_DIR/packaging/click/patches
 
 # Remove old downloads
 rm -rf "${LIBPOSTAL_SRC_DIR}" "${VALHALLA_SRC_DIR}"
 
 # Download sources
 git clone -b 1.0.0 ${CLONE_ARGS} https://github.com/rinigus/pkg-libpostal.git "${LIBPOSTAL_SRC_DIR}"
-git clone -b 3.4.0 ${CLONE_ARGS} https://github.com/rinigus/pkg-valhalla-lite.git "${VALHALLA_SRC_DIR}"
+git clone -b 3.4.0.5 ${CLONE_ARGS} https://github.com/rinigus/pkg-valhalla-lite.git "${VALHALLA_SRC_DIR}"
+
+# Apply patch to valhalla
+cd $VALHALLA_SRC_DIR/valhalla
+git apply $PATCH_DIR/valhalla/0001-gcc13-was-missing-some-std-header-includes-4154.patch

--- a/server/src/systemdservice.cpp
+++ b/server/src/systemdservice.cpp
@@ -102,6 +102,8 @@ void SystemDService::setEnabled(bool e)
 #ifdef IS_LOMIRI
               "WorkingDirectory=/opt/click.ubuntu.com/osmscout-server.jonnius/current/\n"
               "Environment=\"LD_LIBRARY_PATH=/opt/click.ubuntu.com/osmscout-server.jonnius/current/lib/aarch64-linux-gnu/\"\n"
+              "Environment=\"PATH=/opt/click.ubuntu.com/osmscout-server.jonnius/current/lib/aarch64-linux-gnu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"\n"
+
 #endif
               "ExecStart=" + exe_path + " --systemd --quiet\n";
 


### PR DESCRIPTION
This PR adds support for Ubuntu Touch 24.04. It still supports Ubuntu Touch 20.04 (details in README).